### PR TITLE
Add source tally with multiviewer TSL follow

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -12,3 +12,22 @@ setting the host to sim.ereca.fr et using the API token from the website.
 - Routing of all protocols (SDI, audio, GPIO, multiviewer etc...)
 - Optional Take/Clear
 - Port renaming
+- Source tally with multiviewer TSL UMD v5 follow (optional; enable in connection config)
+
+### Source tally / multiviewer TSL
+
+Enable **Enable tally (TSL)** in the connection config. When disabled, no TSL is sent
+and multiviewer UMD names are left alone.
+
+The **Set source tally** action sets **red**, **green**, or **amber** on a
+source. **State** is an On/Off dropdown that also accepts a variable or expression
+resolving to true/false. The module tracks where that source is routed:
+
+- Any destination currently fed by the source inherits the tally.
+- For every multiviewer PIP that shows either that source or a destination carrying
+  it, a TSL UMD v5 packet is sent to the StageRacer host on **UDP port 9801**.
+- The UMD text is the name of whatever is routed into that PIP (source or destination).
+- Addressing uses the multiviewer’s configured `tsl_screen` and the PIP frame index
+
+Use this from Companion Triggers (e.g. driven by an incoming TSL listener) so mixer
+tally can follow StageRacer routing onto multiviewers.

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -198,5 +198,68 @@ export function UpdateActions(self: ModuleInstance): void {
 		},
 	}
 
+	actions['set_source_tally'] = {
+		name: 'Set source tally',
+		description:
+			'Set red, green, or amber tally for a source. Follows routing to destinations and updates multiviewer PIPs via TSL v5 (UDP 9801).',
+		options: [
+			{
+				type: 'dropdown',
+				label: 'Source',
+				id: 'io_key',
+				default: choices_in[0]?.id ?? 'NILIO',
+				choices: choices_in.filter((c) => c.id !== 'NILIO'),
+			},
+			{
+				type: 'dropdown',
+				label: 'Colour',
+				id: 'colour',
+				default: 'red',
+				choices: [
+					{ id: 'red', label: 'Red' },
+					{ id: 'green', label: 'Green' },
+					{ id: 'amber', label: 'Amber' },
+				],
+			},
+			{
+				type: 'dropdown',
+				label: 'State',
+				id: 'state',
+				default: 'true',
+				choices: [
+					{ id: 'true', label: 'On' },
+					{ id: 'false', label: 'Off' },
+				],
+				allowCustom: true,
+				tooltip: 'On/Off, or a variable/expression that resolves to true or false',
+			},
+		],
+		callback: async (action, context) => {
+			const key = action.options.io_key
+			if (!key || typeof key !== 'string' || key === 'NILIO') {
+				return
+			}
+
+			if (!self.ios[key]) {
+				return
+			}
+
+			const colourRaw = action.options.colour
+			const colour = colourRaw === 'green' || colourRaw === 'amber' ? colourRaw : 'red'
+
+			const stateOpt = action.options.state
+			let on: boolean
+			if (typeof stateOpt === 'boolean') {
+				on = stateOpt
+			} else {
+				const stateRaw = await context.parseVariablesInString(`${stateOpt ?? ''}`)
+				const stateNorm = stateRaw.trim().toLowerCase()
+				on = ['true', '1', 'on', 'yes'].includes(stateNorm)
+			}
+
+			self.tally.setSourceTally(key, colour, on)
+		},
+	}
+
 	self.setActionDefinitions(actions)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface ModuleConfig {
 	useHttps: boolean
 	apiToken: string
 	take: boolean
+	enableTally: boolean
 	protoFilter: string
 	pollInterval: number
 }
@@ -55,6 +56,15 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			id: 'take',
 			label: 'Enable Take?',
 			width: 6,
+			default: false,
+		},
+		{
+			type: 'checkbox',
+			id: 'enableTally',
+			label: 'Enable tally (TSL)',
+			width: 6,
+			tooltip:
+				'When enabled, source tally follows routing and updates multiviewer UMD text/tally via TSL v5 on UDP 9801. Disable to avoid overwriting PIP names.',
 			default: false,
 		},
 	]

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,10 +7,12 @@ import { UpdateFeedbacks } from './feedbacks.js'
 import { UpdatePresets } from './presets.js'
 import { UpdateVariableDefinitions } from './variables.js'
 import { RacerProto, Node, IoKey, IoData } from './protocol.js'
+import { TallyManager } from './tally.js'
 
 export class ModuleInstance extends InstanceBase<ModuleConfig> {
 	config!: ModuleConfig // Setup in init()
 	proto: RacerProto | undefined = undefined
+	tally: TallyManager
 	curStatus: [InstanceStatus, string | undefined] | undefined = undefined
 	selectedDestination: IoKey | undefined = undefined
 	// When using "take", this contains the pending routing instructions
@@ -18,6 +20,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 
 	constructor(internal: unknown) {
 		super(internal)
+		this.tally = new TallyManager(this)
 	}
 
 	async init(config: ModuleConfig): Promise<void> {
@@ -26,6 +29,8 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 
 	// When module gets deleted
 	async destroy(): Promise<void> {
+		this.tally.destroy()
+
 		if (this.proto) {
 			this.proto.destroy()
 			this.proto = undefined
@@ -49,6 +54,12 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 			this.config.useHttps = true
 		}
 
+		this.tally.setHost(this.config.host || '')
+
+		if (!this.config.enableTally) {
+			this.tally.disableOutput()
+		}
+
 		if (this.proto) {
 			this.proto.destroy()
 			this.proto = undefined
@@ -59,6 +70,10 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 
 		if (!this.config.take) {
 			this.pendingRoute = undefined
+		}
+
+		if (this.config.enableTally) {
+			this.tally.sync()
 		}
 	}
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -204,6 +204,7 @@ export class RacerProto {
 			}
 
 			this.module.updatePorts()
+			this.module.tally.sync()
 		}
 
 		UpdateTransientVariables(self)
@@ -222,6 +223,8 @@ export class RacerProto {
 		if (iod.protocol == 'SDI_PV' && parent_io) {
 			// For previews we use the multiviewer name
 			iod.name = `F${indices[indices.length - 1]} ${parent_io.name}`
+			iod.parent_key = parent_io.key
+			iod.frame_index = indices[indices.length - 1]
 		}
 
 		// We only care about DANTE_CH protocols, not the DANTE dummy node
@@ -516,6 +519,10 @@ export class IoData {
 	path: Path
 	src_key: IoKey | undefined
 	active_standard: Standard | undefined
+	/** Parent multiviewer IO key (SDI_PV only) */
+	parent_key: IoKey | undefined
+	/** 1-based FRAME index within parent multiviewer (SDI_PV only) */
+	frame_index: number | undefined
 
 	public get enabled(): boolean {
 		return this.io.en
@@ -622,6 +629,17 @@ export class IoData {
 
 	public isMultiview(): boolean {
 		return !!this.getAttr('multi_view')
+	}
+
+	/** TSL UMD v5 screen identifier from multiviewer config, if present */
+	public tslScreen(): number | undefined {
+		const conf = this.getAttr('multi_view')
+		if (!conf || conf.tsl_screen === undefined || conf.tsl_screen === null) {
+			return undefined
+		}
+
+		const screen = Number(conf.tsl_screen)
+		return Number.isFinite(screen) ? screen : undefined
 	}
 
 	public activeStandardBw(): number | undefined {

--- a/src/tally.ts
+++ b/src/tally.ts
@@ -1,0 +1,199 @@
+import type { ModuleInstance } from './main.js'
+import type { IoData, IoKey } from './protocol.js'
+import { TallyColour, TslSender } from './tsl.js'
+
+export type TallyLamp = 'red' | 'green' | 'amber'
+
+type PipTallyState = {
+	text: string
+	red: boolean
+	green: boolean
+	amber: boolean
+}
+
+/**
+ * Source-based tally that follows routing onto destinations and MV PIPs.
+ * MV updates are sent as TSL UMD v5 to the StageRacer host:9801.
+ */
+export class TallyManager {
+	private readonly sender = new TslSender()
+	private redSources = new Set<IoKey>()
+	private greenSources = new Set<IoKey>()
+	private amberSources = new Set<IoKey>()
+	/** Last TSL state sent per screen:display, so we can clear and debounce */
+	private lastPip = new Map<string, PipTallyState>()
+
+	constructor(private readonly module: ModuleInstance) {}
+
+	public destroy(): void {
+		this.sender.destroy()
+		this.redSources.clear()
+		this.greenSources.clear()
+		this.amberSources.clear()
+		this.lastPip.clear()
+	}
+
+	public setHost(host: string): void {
+		this.sender.setHost(host)
+	}
+
+	public setSourceTally(sourceKey: IoKey, lamp: TallyLamp, on: boolean): void {
+		if (on) {
+			// Only one colour active per source
+			this.redSources.delete(sourceKey)
+			this.greenSources.delete(sourceKey)
+			this.amberSources.delete(sourceKey)
+
+			const set = lamp === 'red' ? this.redSources : lamp === 'green' ? this.greenSources : this.amberSources
+			set.add(sourceKey)
+		} else {
+			const set = lamp === 'red' ? this.redSources : lamp === 'green' ? this.greenSources : this.amberSources
+			set.delete(sourceKey)
+		}
+
+		this.sync()
+	}
+
+	public isSourceTallied(sourceKey: IoKey, lamp: TallyLamp = 'red'): boolean {
+		const set = lamp === 'red' ? this.redSources : lamp === 'green' ? this.greenSources : this.amberSources
+		return set.has(sourceKey)
+	}
+
+	/** Stop sending TSL without clearing StageRacer (avoids overwriting names). */
+	public disableOutput(): void {
+		this.lastPip.clear()
+	}
+
+	/**
+	 * Recompute inherited tally from current crosspoints and push TSL to MV PIPs.
+	 * Call after port/routing refresh and after setSourceTally.
+	 */
+	public sync(): void {
+		if (!this.module.config.enableTally) {
+			return
+		}
+
+		const ios = this.module.ios
+
+		const redDestinations = new Set<IoKey>()
+		const greenDestinations = new Set<IoKey>()
+		const amberDestinations = new Set<IoKey>()
+		for (const io of Object.values(ios)) {
+			if (!io.isOutput() || !io.src_key) {
+				continue
+			}
+			if (this.redSources.has(io.src_key)) {
+				redDestinations.add(io.key)
+			}
+			if (this.greenSources.has(io.src_key)) {
+				greenDestinations.add(io.key)
+			}
+			if (this.amberSources.has(io.src_key)) {
+				amberDestinations.add(io.key)
+			}
+		}
+
+		const desired = new Map<string, PipTallyState>()
+
+		for (const pip of Object.values(ios)) {
+			if (pip.protocol !== 'SDI_PV') {
+				continue
+			}
+
+			const addr = this.pipAddress(pip)
+			if (!addr) {
+				continue
+			}
+
+			const shown = pip.src_key ? ios[pip.src_key] : undefined
+			if (!shown) {
+				desired.set(addr.key, { text: '', red: false, green: false, amber: false })
+				continue
+			}
+
+			const red = this.redSources.has(shown.key) || redDestinations.has(shown.key)
+			const green = this.greenSources.has(shown.key) || greenDestinations.has(shown.key)
+			const amber = this.amberSources.has(shown.key) || amberDestinations.has(shown.key)
+
+			desired.set(addr.key, { text: shown.name, red, green, amber })
+		}
+
+		for (const [key, prev] of this.lastPip) {
+			if (!desired.has(key) && (prev.red || prev.green || prev.amber)) {
+				const [screenStr, displayStr] = key.split(':')
+				this.sender.send({
+					screen: Number(screenStr),
+					display: Number(displayStr),
+					text: prev.text,
+					rhTally: TallyColour.Off,
+					lhTally: TallyColour.Off,
+					textTally: TallyColour.Off,
+				})
+			}
+		}
+
+		for (const [key, state] of desired) {
+			const prev = this.lastPip.get(key)
+			if (
+				prev &&
+				prev.text === state.text &&
+				prev.red === state.red &&
+				prev.green === state.green &&
+				prev.amber === state.amber
+			) {
+				continue
+			}
+
+			const [screenStr, displayStr] = key.split(':')
+			const { rh, lh, text } = this.coloursFor(state)
+
+			this.sender.send({
+				screen: Number(screenStr),
+				display: Number(displayStr),
+				text: state.text,
+				rhTally: rh,
+				lhTally: lh,
+				textTally: text,
+			})
+		}
+
+		this.lastPip = desired
+	}
+
+	/** Explicit amber wins; otherwise RH=red, LH=green. */
+	private coloursFor(state: PipTallyState): { rh: number; lh: number; text: number } {
+		if (state.amber) {
+			return { rh: TallyColour.Amber, lh: TallyColour.Amber, text: TallyColour.Amber }
+		}
+
+		return {
+			rh: state.red ? TallyColour.Red : TallyColour.Off,
+			lh: state.green ? TallyColour.Green : TallyColour.Off,
+			text: state.red ? TallyColour.Red : state.green ? TallyColour.Green : TallyColour.Off,
+		}
+	}
+
+	private pipAddress(pip: IoData): { key: string; screen: number; display: number } | undefined {
+		if (pip.frame_index === undefined || !pip.parent_key) {
+			return undefined
+		}
+
+		const parent = this.module.ios[pip.parent_key]
+		if (!parent) {
+			return undefined
+		}
+
+		const screen = parent.tslScreen()
+		if (screen === undefined) {
+			return undefined
+		}
+
+		// StageRacer uses 1-based display indices matching FRAME-N (not TSL's usual 0-based)
+		const display = pip.frame_index
+		if (display < 1) {
+			return undefined
+		}
+
+		return { key: `${screen}:${display}`, screen, display }
+	}
+}

--- a/src/tsl.ts
+++ b/src/tsl.ts
@@ -1,0 +1,99 @@
+import dgram from 'dgram'
+
+export const TSL_PORT = 9801
+
+/** TSL UMD v5 tally colours */
+export const TallyColour = {
+	Off: 0,
+	Red: 1,
+	Green: 2,
+	Amber: 3,
+} as const
+
+export type TslDisplayUpdate = {
+	screen: number
+	/** 0-based display / PIP index */
+	display: number
+	text: string
+	rhTally?: number
+	lhTally?: number
+	textTally?: number
+	brightness?: number
+}
+
+/**
+ * Compose a TSL UMD v5 UDP packet (ASCII labels, display messages).
+ * Spec: little-endian, PBC / VER / FLAGS / SCREEN / DMSG…
+ */
+export function composeTslV5(update: TslDisplayUpdate): Buffer {
+	const textBuf = Buffer.from(update.text ?? '', 'ascii')
+	const brightness = (update.brightness ?? 3) & 0x3
+	const rh = (update.rhTally ?? TallyColour.Off) & 0x3
+	const txt = (update.textTally ?? rh) & 0x3
+	const lh = (update.lhTally ?? TallyColour.Off) & 0x3
+
+	// CONTROL: bits 0-1 RH, 2-3 text, 4-5 LH, 6-7 brightness
+	const control = rh | (txt << 2) | (lh << 4) | (brightness << 6)
+
+	// DMSG body after SCREEN: INDEX(2) + CONTROL(2) + LENGTH(2) + TEXT
+	const dmsgLen = 2 + 2 + 2 + textBuf.length
+	// Packet after PBC: VER(1) + FLAGS(1) + SCREEN(2) + DMSG
+	const afterPbc = 1 + 1 + 2 + dmsgLen
+
+	const buf = Buffer.alloc(2 + afterPbc)
+	let o = 0
+	buf.writeUInt16LE(afterPbc, o)
+	o += 2
+	buf.writeUInt8(0, o++) // VER
+	buf.writeUInt8(0, o++) // FLAGS: ASCII, display data
+	buf.writeUInt16LE(update.screen & 0xffff, o)
+	o += 2
+	buf.writeUInt16LE(update.display & 0xffff, o)
+	o += 2
+	buf.writeUInt16LE(control & 0xffff, o)
+	o += 2
+	buf.writeUInt16LE(textBuf.length & 0xffff, o)
+	o += 2
+	textBuf.copy(buf, o)
+
+	return buf
+}
+
+export class TslSender {
+	private socket: dgram.Socket | undefined
+	private host: string = ''
+
+	public setHost(host: string): void {
+		this.host = host.trim()
+	}
+
+	public destroy(): void {
+		if (this.socket) {
+			this.socket.close()
+			this.socket = undefined
+		}
+	}
+
+	public send(update: TslDisplayUpdate): void {
+		if (!this.host) {
+			return
+		}
+
+		const packet = composeTslV5(update)
+
+		if (!this.socket) {
+			this.socket = dgram.createSocket('udp4')
+			this.socket.on('error', () => {
+				// Recreate on next send
+				try {
+					this.socket?.close()
+				} catch {
+					/* ignore */
+				}
+				this.socket = undefined
+			})
+		}
+
+		this.socket.send(packet, TSL_PORT, this.host)
+	}
+}


### PR DESCRIPTION
## Summary
- Add **Set source tally** action that follows a source through StageRacer routing
- Push TSL UMD v5 (UDP 9801) to MV PIPs using ``tsl_screen`` + 1-based FRAME index
- UMD text is the name of the source/destination shown on that PIP
- Gate with connection config **Enable tally (TSL)** (default off) so names are not overwritten unless enabled
## Test plan
- [ ] Load as developer module; confirm **Enable tally (TSL)** appears in config
- [ ] With tally disabled, Set source tally does not change MV UMD names
- [ ] With tally enabled, tallied source on a PIP shows red + correct label on the correct window
- [ ] Route the tallied source to another PIP / via a destination shown on a PIP; tally follows
- [ ] Clear tally (off); red clears on affected PIPs